### PR TITLE
EditorHandler trait improvements

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -79,8 +79,6 @@ impl SimpleEditor {
 }
 
 impl EditorHandler for SimpleEditor {
-    fn init(&mut self, _: &mut Context) {}
-
     fn on_frame(&mut self, _: &mut Context) {}
 
     fn on_message(&mut self, send_message: &dyn Fn(String), message: String) {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -81,9 +81,9 @@ impl SimpleEditor {
 impl EditorHandler for SimpleEditor {
     fn on_frame(&mut self, _: &mut Context) {}
 
-    fn on_message(&mut self, send_message: &dyn Fn(String), message: String) {
+    fn on_message(&mut self, cx: &mut Context, message: String) {
         println!("Received message: {:?}", message);
-        send_message("Hello from Rust!".to_string());
+        cx.send_message("Hello from Rust!".to_string());
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,9 +9,17 @@ use wry::{
 use crate::WebViewState;
 
 pub trait EditorHandler: Send + 'static {
-    fn init(&mut self, cx: &mut Context);
     fn on_frame(&mut self, cx: &mut Context);
-    fn on_message(&mut self, send_message: &dyn Fn(String), message: String);
+    /// This callback is executed when a message is received from the UI.
+    /// This can and should be used to handle initialization as well. (see the example below).
+    /// ### Init Example
+    /// ```rust
+    /// match &*message {
+    ///    "Ready" => cx.send_message("<your data here>".to_string()),
+    ///    ...
+    /// }
+    /// ```
+    fn on_message(&mut self, cx: &mut Context, message: String);
 }
 
 pub struct Context {


### PR DESCRIPTION
Specifically, this PR removes `init()`, and instead includes some documentation on handling initialization within `on_message()`. 

Furthermore, `on_message()` now has access to `Context`. This also involved a small amount of refactoring in the IPC handler.